### PR TITLE
Added context to permit cleartext communication with opentranslationtools.org

### DIFF
--- a/translationRecorder/app/src/main/AndroidManifest.xml
+++ b/translationRecorder/app/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/TR.NoActionBar"
+        android:networkSecurityConfig="@xml/network_security_config"
         tools:replace="android:theme">
 
         <!-- Splash screen -->

--- a/translationRecorder/app/src/main/res/xml/network_security_config.xml
+++ b/translationRecorder/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+	<domain-config cleartextTrafficPermitted="true">
+		<domain includeSubdomains="true">opentranslationtools.org</domain>
+	</domain-config>
+</network-security-config>


### PR DESCRIPTION
Tested working on a Samsung tablet that was previously unable to upload to BTT-Exchanger.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/btt-recorder/46)
<!-- Reviewable:end -->
